### PR TITLE
fix:(schedule-trivy): only scan for vulns

### DIFF
--- a/.github/workflows/schedule-trivy.yaml
+++ b/.github/workflows/schedule-trivy.yaml
@@ -18,6 +18,7 @@ jobs:
           image-ref: ${{ inputs.image-ref }}
           format: 'sarif'
           ignore-unfixed: true
+          security-checks: 'vuln'
           output: 'trivy-results.sarif'
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
The secret scanner is too slow and also doesn't make sense in a scheduled job.