### PR TITLE
fix(release-container): cache loading with cache-from: type=gha

### DIFF
--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -115,6 +115,7 @@ jobs:
           load: true
           push: false
           tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
           cache-to: type=gha,mode=max
           labels: |
             ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
See https://docs.docker.com/build/ci/github-actions/cache/#cache-backend-api.
