### PR TITLE
fix(trivy): add ecr registry as a fallback option for trivy db

### DIFF
--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -125,6 +125,9 @@ jobs:
             
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           image-ref: '${{ inputs.image }}:${{ steps.meta.outputs.version }}'
           format: 'json'

--- a/.github/workflows/schedule-trivy.yaml
+++ b/.github/workflows/schedule-trivy.yaml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         with:
           image-ref: ${{ inputs.image-ref }}
           timeout: ${{ inputs.timeout }}


### PR DESCRIPTION
This add ECR images as a fallback to work around https://github.com/aquasecurity/trivy-action/issues/389.

If all goes well we should see much less TOOMANYREQUEST errors, if it doesn't end up working we'll have to explore hosting our own mirror of the DB.