### PR TITLE
fix(sigstore): downgrade sigstore installer to v3.10.0

### DIFF
--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -98,7 +98,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
+        uses: sigstore/cosign-installer@v3.10.0
 
       - name: Prepare additional Metadata
         id: additional_meta

--- a/.github/workflows/schedule-trivy.yaml
+++ b/.github/workflows/schedule-trivy.yaml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
+        uses: sigstore/cosign-installer@v3.10.0
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.33.1


### PR DESCRIPTION
The v4 release instroduced a ton of changes and the ecosystem doesn't seem to be ready yet.