### PR TITLE
fix(trivy): use v prefix in version

### DIFF
--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -162,7 +162,7 @@ jobs:
           DOCKER_CONTENT_TRUST: 1
             
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.35.0
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
@@ -174,7 +174,7 @@ jobs:
           output: 'trivy.json'
 
       - name: Convert trivy results to sarif
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: trivy.json
           scan-type: 'convert'
@@ -223,7 +223,7 @@ jobs:
           TAGS: ${{ steps.meta.outputs.tags }}
 
       - name: Convert trivy results to CycloneDX
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: trivy.json
           scan-type: 'convert'
@@ -239,7 +239,7 @@ jobs:
         if: github.event_name != 'pull_request' && startsWith(github.event.ref, 'refs/tags/v')
 
       - name: Convert trivy results to cosign-vuln
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: trivy.json
           scan-type: 'convert'

--- a/.github/workflows/schedule-trivy.yaml
+++ b/.github/workflows/schedule-trivy.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: sigstore/cosign-installer@v3.10.1
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.35.0
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
@@ -41,7 +41,7 @@ jobs:
           output: 'trivy.json'
 
       - name: Convert trivy results to sarif
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: trivy.json
           scan-type: 'convert'
@@ -59,7 +59,7 @@ jobs:
           sarif_file: 'trivy.sarif'
 
       - name: Convert trivy results to cosign-vuln
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: trivy.json
           scan-type: 'convert'


### PR DESCRIPTION
## Summary

<!-- Describe the change and link to the related issue. -->
Add a v prefix to version as described in https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0

Closes #

## Type of Change

- [x] 🐛 Bug fix — patch version bump
- [ ] ✨ New workflow — minor version bump
- [ ] 🔧 Update existing workflow — patch or minor version bump
- [ ] 🗑️ EOL / deprecate workflow
- [ ] 📖 Documentation only
- [ ] 🔒 Security improvement
- [ ] 🤖 Dependency / tooling update

## Checklist

- [ ] Workflow YAML is created or updated under `.github/workflows/`
- [ ] Documentation is created or updated under `docs/workflows/`
- [ ] Permissions table in `docs/permissions.md` is updated
- [ ] `mkdocs.yml` nav is updated (required when a new docs page is added)
- [ ] `AGENTS.md` is updated (required when repository structure or conventions change)
- [ ] All caller examples include `permissions: {}` at the workflow level with explicit per-job permissions
- [ ] Any new third-party actions are pinned to a released version tag (e.g. `@v3`)
- [ ] For breaking changes: migration guidance is included in the docs and commit message contains `BREAKING CHANGE:`
- [ ] For EOL: deprecation notice is added to the workflow YAML and docs
