### PR TITLE
chore: add empty top-level permission blocks for all actions

### DIFF
--- a/.github/workflows/release-ansible-collection.yaml
+++ b/.github/workflows/release-ansible-collection.yaml
@@ -10,6 +10,8 @@ on:
     secrets:
       GALAXY_API_KEY:
         required: true
+
+permissions: {}
         
 jobs:
   build:

--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -74,6 +74,8 @@ on:
         required: false
         type: string
 
+permissions: {}
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-mkdocs.yaml
+++ b/.github/workflows/release-mkdocs.yaml
@@ -6,6 +6,8 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-python-poetry.yaml
+++ b/.github/workflows/release-python-poetry.yaml
@@ -6,6 +6,8 @@ on:
       RABE_PYPI_TOKEN:
         required: true
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/schedule-trivy.yaml
+++ b/.github/workflows/schedule-trivy.yaml
@@ -13,6 +13,8 @@ on:
         default: '5m0s'
         type: string
 
+permissions: {}
+
 jobs:
   trivy:
     runs-on: ubuntu-latest

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -10,6 +10,8 @@ on:
       RABE_ITREAKTION_GITHUB_TOKEN:
         required: true
 
+permissions: {}
+
 jobs:
   semantic-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-ansible-collection.yaml
+++ b/.github/workflows/test-ansible-collection.yaml
@@ -9,6 +9,8 @@ on:
         type: string
         default: "."
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-pre-commit.yaml
+++ b/.github/workflows/test-pre-commit.yaml
@@ -9,6 +9,8 @@ on:
         type: string
         default: "black isort flake8"
 
+permissions: {}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-python-poetry.yaml
+++ b/.github/workflows/test-python-poetry.yaml
@@ -9,6 +9,8 @@ on:
         default: '3.12'
         type: string
 
+permissions: {}
+
 jobs:
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

<!-- Describe the change and link to the related issue. -->

Closes #

## Type of Change

- [ ] 🐛 Bug fix — patch version bump
- [ ] ✨ New workflow — minor version bump
- [x] 🔧 Update existing workflow — patch or minor version bump
- [ ] 🗑️ EOL / deprecate workflow
- [ ] 📖 Documentation only
- [x] 🔒 Security improvement (minor only)
- [ ] 🤖 Dependency / tooling update

## Checklist

- [x] Workflow YAML is created or updated under `.github/workflows/`
- [ ] Documentation is created or updated under `docs/workflows/`
- [ ] Permissions table in `docs/permissions.md` is updated
- [ ] `mkdocs.yml` nav is updated (required when a new docs page is added)
- [ ] `AGENTS.md` is updated (required when repository structure or conventions change)
- [ ] All caller examples include `permissions: {}` at the workflow level with explicit per-job permissions
- [ ] All third-party actions are pinned to a commit SHA with version tag comment (e.g. `@abc1234 # v3`)
- [ ] For breaking changes: migration guidance is included in the docs and commit message contains `BREAKING CHANGE:`
- [ ] For EOL: deprecation notice is added to the workflow YAML and docs
