### PR TITLE
fix(test-ansible-collection): replace flake8 and black with ruff

### DIFF
--- a/.github/workflows/test-ansible-collection.yaml
+++ b/.github/workflows/test-ansible-collection.yaml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   lint:
-    name: Lint with ansible-lint, black, and flake8
+    name: Lint with ansible-lint and ruff
     runs-on: ubuntu-latest
 
     permissions:
@@ -29,17 +29,18 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install flake8
-          pip install --pre black
+      - name: Install ruff
+        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
 
       - name: Lint with flake8
-        run: flake8 . --count --show-source --statistics
+        run: ruff check --diff ${INPUTS_PATH}
+        env:
+          INPUTS_PATH: ${{ inputs.path }}
 
       - name: Lint with black
-        run: black --check --diff .
+        run: ruff format ${INPUTS_PATH}
+        env:
+          INPUTS_PATH: ${{ inputs.path }}
 
       - name: Lint with ansible-lint
         uses: ansible/ansible-lint@5fac056c45595896c973fbde871f01f6cb14d74c # v26.4.0

--- a/docs/workflows/ansible/index.md
+++ b/docs/workflows/ansible/index.md
@@ -6,4 +6,4 @@ Workflows for testing Ansible collections and releasing them to
 | Workflow | Description |
 |---|---|
 | [Release](release.md) | Build and publish an Ansible collection to Galaxy |
-| [Test](test.md) | Lint an Ansible collection with ansible-lint, flake8, and black |
+| [Test](test.md) | Lint an Ansible collection with ansible-lint and ruff |

--- a/docs/workflows/ansible/test.md
+++ b/docs/workflows/ansible/test.md
@@ -1,6 +1,6 @@
 # Ansible Collection: Test
 
-Lints an Ansible collection with ansible-lint, flake8, and black.
+Lints an Ansible collection with ansible-lint and ruff.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
The Python ecosystem has moved from flake8 and black to ruff. This implements the shift for our ansible collections.

## Type of Change

- [ ] 🐛 Bug fix — patch version bump
- [ ] ✨ New workflow — minor version bump
- [x] 🔧 Update existing workflow — patch or minor version bump
- [ ] 🗑️ EOL / deprecate workflow
- [ ] 📖 Documentation only
- [ ] 🔒 Security improvement
- [ ] 🤖 Dependency / tooling update

## Checklist

- [x] Workflow YAML is created or updated under `.github/workflows/`
- [x] Documentation is created or updated under `docs/workflows/`
- [ ] Permissions table in `docs/security/permissions.md` is updated
- [ ] `mkdocs.yml` nav is updated (required when a new docs page is added)
- [ ] `AGENTS.md` is updated (required when repository structure or conventions change)
- [ ] All caller examples include `permissions: {}` at the workflow level with explicit per-job permissions
- [x] All third-party actions are pinned to a commit SHA with version tag comment (e.g. `@abc1234 # v3`)
- [x] Any new third-party actions have been evaluated against the [action selection criteria](https://radiorabe.github.io/actions/security/supply-chain/#action-selection-criteria)
- [ ] No new known-vulnerable dependencies have been introduced (check Dependabot alerts and [thresholds](https://radiorabe.github.io/actions/security/vulnerability-management/)).
- [ ] For breaking changes: migration guidance is included in the docs and commit message contains `BREAKING CHANGE:`
- [ ] For EOL: deprecation notice is added to the workflow YAML and docs