### PR TITLE
fix(test-ansible-collection): fix ruff call

### DIFF
--- a/.github/workflows/test-ansible-collection.yaml
+++ b/.github/workflows/test-ansible-collection.yaml
@@ -32,13 +32,13 @@ jobs:
       - name: Install ruff
         uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
 
-      - name: Lint with flake8
+      - name: Lint with ruff
         run: ruff check --diff ${INPUTS_PATH}
         env:
           INPUTS_PATH: ${{ inputs.path }}
 
-      - name: Lint with black
-        run: ruff format ${INPUTS_PATH}
+      - name: Format with ruff
+        run: ruff format --diff ${INPUTS_PATH}
         env:
           INPUTS_PATH: ${{ inputs.path }}
 


### PR DESCRIPTION
## Summary

Fixes the fail in https://github.com/radiorabe/ansible-collection-rabe_foreman/pull/300

Closes #

## Type of Change

- [x] 🐛 Bug fix — patch version bump
- [ ] ✨ New workflow — minor version bump
- [ ] 🔧 Update existing workflow — patch or minor version bump
- [ ] 🗑️ EOL / deprecate workflow
- [ ] 📖 Documentation only
- [ ] 🔒 Security improvement
- [ ] 🤖 Dependency / tooling update

## Checklist

- [x] Workflow YAML is created or updated under `.github/workflows/`
- [ ] Documentation is created or updated under `docs/workflows/`
- [ ] Permissions table in `docs/security/permissions.md` is updated
- [ ] `mkdocs.yml` nav is updated (required when a new docs page is added)
- [ ] `AGENTS.md` is updated (required when repository structure or conventions change)
- [ ] All caller examples include `permissions: {}` at the workflow level with explicit per-job permissions
- [ ] All third-party actions are pinned to a commit SHA with version tag comment (e.g. `@abc1234 # v3`)
- [ ] Any new third-party actions have been evaluated against the [action selection criteria](https://radiorabe.github.io/actions/security/supply-chain/#action-selection-criteria)
- [ ] No new known-vulnerable dependencies have been introduced (check Dependabot alerts and [thresholds](https://radiorabe.github.io/actions/security/vulnerability-management/)).
- [ ] For breaking changes: migration guidance is included in the docs and commit message contains `BREAKING CHANGE:`
- [ ] For EOL: deprecation notice is added to the workflow YAML and docs
