### PR TITLE
fix(release-python-poetry): Add deploy-mkdocs flag to disable mkdocs gh-deploy

### DIFF
--- a/.github/workflows/release-python-poetry.yaml
+++ b/.github/workflows/release-python-poetry.yaml
@@ -8,6 +8,10 @@ on:
         required: false
         default: "."
         type: string
+      deploy-mkdocs:
+        description: Deploy MkDocs site to GitHub Pages
+        type: boolean
+        default: true
     secrets:
       RABE_PYPI_TOKEN:
         required: false
@@ -72,6 +76,6 @@ jobs:
         working-directory: ${{ inputs.path }}
 
       - name: Deploy documentation
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ inputs.deploy-mkdocs && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: poetry run mkdocs gh-deploy
         working-directory: ${{ inputs.path }}

--- a/docs/workflows/python/release.md
+++ b/docs/workflows/python/release.md
@@ -1,7 +1,7 @@
 # Python: Release (Poetry)
 
 Publishes a Python package to [PyPI](https://pypi.org/) using
-[Poetry](https://python-poetry.org/) and deploys [MkDocs](https://www.mkdocs.org/)
+[Poetry](https://python-poetry.org/) and (optionally) deploys [MkDocs](https://www.mkdocs.org/)
 documentation to GitHub Pages.
 
 ## Usage
@@ -36,6 +36,12 @@ jobs:
 
 Configure your `pyproject.toml` for releasing and your `mkdocs.yml` to generate proper
 documentation and you are good to go.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|---|---|---|---|
+| `deploy-mkdocs` | Run `mkdocs gh-pages` | No | `true` |
 
 ## Secrets
 


### PR DESCRIPTION
## Summary

This opens the path towards a separate release-zensical job in affected repos

## Type of Change

- [x] 🐛 Bug fix — patch version bump
- [ ] ✨ New workflow — minor version bump
- [ ] 🔧 Update existing workflow — patch or minor version bump
- [ ] 🗑️ EOL / deprecate workflow
- [ ] 📖 Documentation only
- [ ] 🔒 Security improvement
- [ ] 🤖 Dependency / tooling update

## Checklist

- [x] Workflow YAML is created or updated under `.github/workflows/`
- [x] Documentation is created or updated under `docs/workflows/`
- [ ] Permissions table in `docs/security/permissions.md` is updated
- [ ] `mkdocs.yml` nav is updated (required when a new docs page is added)
- [ ] `AGENTS.md` is updated (required when repository structure or conventions change)
- [ ] All caller examples include `permissions: {}` at the workflow level with explicit per-job permissions
- [ ] All third-party actions are pinned to a commit SHA with version tag comment (e.g. `@abc1234 # v3`)
- [ ] Any new third-party actions have been evaluated against the [action selection criteria](https://radiorabe.github.io/actions/security/supply-chain/#action-selection-criteria)
- [ ] No new known-vulnerable dependencies have been introduced (check Dependabot alerts and [thresholds](https://radiorabe.github.io/actions/security/vulnerability-management/)).
- [ ] For breaking changes: migration guidance is included in the docs and commit message contains `BREAKING CHANGE:`
- [ ] For EOL: deprecation notice is added to the workflow YAML and docs
