### PR TITLE
fix(release-container): replace `cosign dockerfile verify` with `cosign verify`

### DIFF
--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -34,8 +34,13 @@ on:
         required: false
         default: "https://github.com/radiorabe/.*"
         type: string
+      cosign-image-skip-regexp:
+        description: "Regex to exclude some images from cosign image scan"
+        required: false
+        default: "#"
+        type: string
       cosign-base-image-only:
-        description: "pass --base-image-only arg to cosign dockerfile verify"
+        description: "DEPRECATED: not supported by cosign verify"
         required: false
         default: false
         type: boolean
@@ -145,20 +150,16 @@ jobs:
       - name: Verify ${{ inputs.dockerfile }} using cosign
         if: inputs.cosign-verify
         env:
-          COSIGN_BASE_IMAGE_ONLY: ${{ inputs.cosign-base-image-only }}
+          COSIGN_IMAGE_SKIP_REGEXP: ${{ inputs.cosign-image-skip-regexp }}
           COSIGN_CERTIFICATE_IDENTITY_REGEXP: ${{ inputs.cosign-certificate-identity-regexp }}
           COSIGN_CERTIFICATE_OIDC_ISSUER: ${{ inputs.cosign-certificate-oidc-issuer }}
           DOCKERFILE: ${{ inputs.dockerfile }}
         run: |
           set -euo pipefail
-          EXTRA=''
-          if [ "${COSIGN_BASE_IMAGE_ONLY}" = 'true' ]; then
-            EXTRA='--base-image-only'
-          fi
-          cosign dockerfile verify \
+          cosign verify \
             --certificate-oidc-issuer "${COSIGN_CERTIFICATE_OIDC_ISSUER}" \
             --certificate-identity-regexp "${COSIGN_CERTIFICATE_IDENTITY_REGEXP}" \
-            ${EXTRA} -- "${DOCKERFILE}" > /dev/null
+          -- $(gawk 'BEGIN {IGNORECASE=1} match($0, /^\s*FROM\s+(--platform=\S+\s+)?(\S+)(\s+AS\s+(\S+))?/, a) {if (a[2] != "scratch") print a[2]; if (a[4] != "") s[a[4]] = 1; next} match($0, /^\s*COPY\s+.*--from=(\S+)/, a) {if (a[1] !~ /^[0-9]+$/ && a[1] != "scratch" && !(a[1] in s)) print a[1]}' ${DOCKERFILE} | grep -E -v -i ${COSIGN_IMAGE_SKIP_REGEXP}) > /dev/null
 
       - name: Build Container Image
         id: docker_build

--- a/docs/workflows/container/release.md
+++ b/docs/workflows/container/release.md
@@ -59,7 +59,8 @@ As a last step, it is recommended to add `trivy.*` to both your `.gitignore` and
 | `cosign-verify` | Enable cosign verification of the base image | No | `true` |
 | `cosign-certificate-oidc-issuer` | Issuer used for keyless signature verification | No | `https://token.actions.githubusercontent.com` |
 | `cosign-certificate-identity-regexp` | Regex to verify the subject against | No | `https://github.com/radiorabe/.*` |
-| `cosign-base-image-only` | Pass `--base-image-only` to cosign dockerfile verify | No | `false` |
+| `cosign-image-skip-regexp` | Extended regular expression (egrep style) to filter images that skip cosign verification, pipe-separated | No | `#` |
+| `cosign-base-image-only` | DEPRECATED: not supported by `cosign verify`, use `cosign-image-skip-regexp` instead | No | `false` |
 | `dockerfile` | Path to the Dockerfile | No | `Dockerfile` |
 | `context` | Context directory for Docker build | No | `.` |
 | `build-args` | Build ARGs (`KEY=value` separated by newlines) | No | `""` |


### PR DESCRIPTION
## Summary

<!-- Describe the change and link to the related issue. -->
Replace the `cosign dockerfile verify` with a simple awk based wrapper for `cosign verify`.

Closes #238 with the simple fix.

## Type of Change

- [x] 🐛 Bug fix — patch version bump
- [ ] ✨ New workflow — minor version bump
- [x] 🔧 Update existing workflow — patch or minor version bump
- [ ] 🗑️ EOL / deprecate workflow
- [ ] 📖 Documentation only
- [ ] 🔒 Security improvement
- [ ] 🤖 Dependency / tooling update

## Checklist

- [x] Workflow YAML is created or updated under `.github/workflows/`
- [x] Documentation is created or updated under `docs/workflows/`
- [ ] Permissions table in `docs/security/permissions.md` is updated
- [ ] `mkdocs.yml` nav is updated (required when a new docs page is added)
- [ ] `AGENTS.md` is updated (required when repository structure or conventions change)
- [ ] All caller examples include `permissions: {}` at the workflow level with explicit per-job permissions
- [ ] All third-party actions are pinned to a commit SHA with version tag comment (e.g. `@abc1234 # v3`)
- [ ] Any new third-party actions have been evaluated against the [action selection criteria](https://radiorabe.github.io/actions/security/supply-chain/#action-selection-criteria)
- [x] No new known-vulnerable dependencies have been introduced (check Dependabot alerts and [thresholds](https://radiorabe.github.io/actions/security/vulnerability-management/)).
- [ ] For breaking changes: migration guidance is included in the docs and commit message contains `BREAKING CHANGE:`
- [x] For EOL: deprecation notice is added to the workflow YAML and docs
