### PR TITLE
docs: well, copilot, i guess

### DIFF
--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -34,7 +34,7 @@ Status: ✅ Implemented · ⚠️ Partial · ❌ Gap · N/A Not applicable
 | 4.1.2 Known Vulnerabilities | Check vulnerability databases before adopting a dependency | ⚠️ | Dependabot alerts exist; pre-adoption scanning not yet automated — see [#194](https://github.com/radiorabe/actions/issues/194) |
 | 4.1.3 Signing & Integrity | Use cryptographic signing to verify integrity | ✅ | SHA pinning is cryptographic integrity for actions; cosign + SLSA for containers |
 | 4.1.4 Maintainer Reputation | Select packages from reputable, verified maintainers | ⚠️ | Criteria documented in [Supply Chain](supply-chain.md#action-selection-criteria); process gap for automated checks |
-| 4.1.5 Popularity & Maintenance | Community adoption, recent activity, commit history | ⚠️ | Criteria documented in [Supply Chain](supply-chain.md#action-selection-criteria) || 4.1.6 Secure Practices | Evaluate the action's own security posture | ⚠️ | SHA enforcement covers SHA integrity; formal posture checklist in [Supply Chain](supply-chain.md#action-selection-criteria) |
+| 4.1.5 Popularity & Maintenance | Community adoption, recent activity, commit history | ⚠️ | Criteria documented in [Supply Chain](supply-chain.md#action-selection-criteria) |
 | 4.1.6 Secure Practices | Evaluate the action's own security posture | ⚠️ | Criteria documented in [Supply Chain](supply-chain.md#action-selection-criteria); this library's own workflows are zizmor-pedantic linted |
 
 ### §4.2 Package Integration


### PR DESCRIPTION
## Summary

<!-- Describe the change and link to the related issue. -->

Closes #

## Type of Change

- [ ] 🐛 Bug fix — patch version bump
- [ ] ✨ New workflow — minor version bump
- [ ] 🔧 Update existing workflow — patch or minor version bump
- [ ] 🗑️ EOL / deprecate workflow
- [x] 📖 Documentation only
- [ ] 🔒 Security improvement
- [ ] 🤖 Dependency / tooling update

## Checklist

- [ ] Workflow YAML is created or updated under `.github/workflows/`
- [ ] Documentation is created or updated under `docs/workflows/`
- [ ] Permissions table in `docs/security/permissions.md` is updated
- [ ] `mkdocs.yml` nav is updated (required when a new docs page is added)
- [ ] `AGENTS.md` is updated (required when repository structure or conventions change)
- [ ] All caller examples include `permissions: {}` at the workflow level with explicit per-job permissions
- [ ] All third-party actions are pinned to a commit SHA with version tag comment (e.g. `@abc1234 # v3`)
- [ ] Any new third-party actions have been evaluated against the [action selection criteria](https://radiorabe.github.io/actions/security/supply-chain/#action-selection-criteria)
- [ ] No new known-vulnerable dependencies have been introduced (check Dependabot alerts and [thresholds](https://radiorabe.github.io/actions/security/vulnerability-management/)).
- [ ] For breaking changes: migration guidance is included in the docs and commit message contains `BREAKING CHANGE:`
- [ ] For EOL: deprecation notice is added to the workflow YAML and docs
